### PR TITLE
Make all parts of selector configurable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,165 +1,179 @@
 variable "namespace" {
 
-    type        = string
-    description = "cluster namespace"
+  type        = string
+  description = "cluster namespace"
 
 }
 
 variable "name" {
 
-    type        = string
-    description = "cluster name"
+  type        = string
+  description = "cluster name"
 
 }
 
-variable "role" {
+variable "selector_operator" {
 
-    type        = string
-    description = "run on on nodes matching selector"
+  type        = string
+  default     = "In"
+  description = "what operator to use for the selector"
+
+}
+variable "selector_key" {
+
+  type        = string
+  default     = "role"
+  description = "what key to run the selector on"
+
+}
+
+variable "selector_value" {
+  type        = string
+  description = "run on on nodes matching selector"
 
 }
 
 variable "image" {
 
-    type        = string
-    description = "docker image"
-    default     = "rabbitmq:3-management"
+  type        = string
+  description = "docker image"
+  default     = "rabbitmq:3-management"
 
 }
 
 variable "cookie" {
 
-    type        = string
-    description = "rabbitmq cookie string"
-    default     = "changeme"
+  type        = string
+  description = "rabbitmq cookie string"
+  default     = "changeme"
 
 }
 
 variable "request_cpu" {
 
-    type        = string
-    description = "cpu request"
-    default     = "1000m"
+  type        = string
+  description = "cpu request"
+  default     = "1000m"
 
 }
 
 variable "request_memory" {
 
-    type        = string
-    description = "memory request"
-    default     = "2Gi"
+  type        = string
+  description = "memory request"
+  default     = "2Gi"
 
 }
 
 variable "limit_cpu" {
 
-    type        = string
-    description = "cpu limit"
-    default     = "1000m"
+  type        = string
+  description = "cpu limit"
+  default     = "1000m"
 
 }
 
 variable "limit_memory" {
 
-    type        = string
-    description = "memory limit"
-    default     = "2Gi"
+  type        = string
+  description = "memory limit"
+  default     = "2Gi"
 
 }
 
 variable "replicas" {
 
-    type        = number
-    description = "number of replica pods"
-    default     = 1
+  type        = number
+  description = "number of replica pods"
+  default     = 1
 
 }
 
 variable "storage_gb" {
 
-    type        = number
-    description = "storage size in gb"
-    default     = 10
+  type        = number
+  description = "storage size in gb"
+  default     = 10
 
 }
 
 variable "storage_class" {
 
-    type        = string
-    description = "storage class name"
-    default     = 10
+  type        = string
+  description = "storage class name"
+  default     = 10
 
 }
 
 variable "service" {
 
-    description = "service annotations"
+  description = "service annotations"
 
-    default = {
+  default = {
 
-        type = "ClusterIP"
+    type = "ClusterIP"
 
-    }
+  }
 
 }
 
 variable "persistence" {
 
-    type        = map
-    description = "persistence object definition"
-    default     = {
+  type        = map(any)
+  description = "persistence object definition"
+  default = {
 
-        storageClassName = "gp2"
-        storage          = "10Gi"
+    storageClassName = "gp2"
+    storage          = "10Gi"
 
-    }
+  }
 
 }
 
 variable "additional_plugins" {
 
-    type        = list(string)
-    description = "plugins to install"
-    default     = [
+  type        = list(string)
+  description = "plugins to install"
+  default = [
 
-        "rabbitmq_management",
-        "rabbitmq_top",
-        "rabbitmq_shovel",
-        "rabbitmq_prometheus",
-        "rabbitmq_peer_discovery_k8s"
+    "rabbitmq_management",
+    "rabbitmq_top",
+    "rabbitmq_shovel",
+    "rabbitmq_prometheus",
+    "rabbitmq_peer_discovery_k8s"
 
-    ]
+  ]
 
 }
 
 variable "labels" {
 
-    type        = map
-    description = "labels"
-    default     = null
+  type        = map(any)
+  description = "labels"
+  default     = null
 
 }
 
 variable "default_username" {
 
-    type        = string
-    description = "username to create"
-    default     = null
+  type        = string
+  description = "username to create"
+  default     = null
 
 }
 
 variable "default_password" {
 
-    type        = string
-    description = "password to set"
-    default     = null
+  type        = string
+  description = "password to set"
+  default     = null
 
 }
 
 variable "internal_cidrs" {
 
-    type        = string
-    description = "cidrs to whitelist for loadbalancer"
-    default     = "8.0.0.224/32,172.9.9.0/24"
+  type        = string
+  description = "cidrs to whitelist for loadbalancer"
+  default     = "8.0.0.224/32,172.9.9.0/24"
 
 }


### PR DESCRIPTION
Currently only `role` is usable for assigning the rabbitmq pods to nodes, but a lot of cloud providers (aws, digitalocean) don't allow you to set registered keywords as node labels, that includes `node-role.kubernetes.io/blah=blah`

Making the node selector fields configurable fixes this 